### PR TITLE
Hiding HEAD~10 is not the same as log -10

### DIFF
--- a/source/_posts/2013-05-02-revwalk.markdown
+++ b/source/_posts/2013-05-02-revwalk.markdown
@@ -20,7 +20,7 @@ Let's take a look at how that turns out:
 ```c
   void visit(git_commit *c)
   {
-    ize_t i, num_parents = git_commit_parentcount(c);
+    size_t i, num_parents = git_commit_parentcount(c);
 
     /* Print some stuff about this commit */
     char oidstr[10] = {0};


### PR DESCRIPTION
Passing -10 to git-log makes it limit the amount of commits it will
handle (output). Hiding HEAD~10 stops processing at the 10th
grandparent of the current commit through the first-parent line, which
is what ^HEAD~10 does.

The only time these two options will produce the same output is when
there are no merges between HEAD and HEAD~10. In any other case, they
will produce output which can be vastly different.

---

For example, in libgit2:

```
% git log --oneline HEAD ^HEAD~10 | wc -l
30
% git log --oneline -10 HEAD | wc -l     
10
```
